### PR TITLE
Use a seperate flag for enabling dev logging to stdout in order to avoid

### DIFF
--- a/src/xscontainer/util/log.py
+++ b/src/xscontainer/util/log.py
@@ -6,7 +6,7 @@ import sys
 import traceback
 
 ENABLE_DEV_LOGGING_FILE = ("/opt/xensource/packages/files/xscontainer/"
-                           "devmode_enabled")
+                           "devlogging_enabled")
 
 LOG_FILE = "/var/log/xscontainer.log"
 


### PR DESCRIPTION
tripping up CLI calls.

When enabling devmode, XenRT is parsing the output of stdout which includes not
only the plugin XML, but also the xscontainer logging. Using a seperate flag
provides greater amounts of control in this regard.

Signed-off-by: Rob Dobson rob.dobson@citrix.com
