### PR TITLE
Update api_helper.py

### DIFF
--- a/src/xscontainer/api_helper.py
+++ b/src/xscontainer/api_helper.py
@@ -381,7 +381,7 @@ def import_disk(session, sruuid, filename, fileformat, namelabel,
 def export_disk(session, vdiuuid):
     log.info("export_disk vdi %s" % (vdiuuid))
     filename = tempfile.mkstemp(suffix='.raw')[1]
-    cmd = ['curl', '-k', '-o', filename,
+    cmd = ['curl', '-L', '-k', '-o', filename,
            'https://localhost/export_raw_vdi?session_id=%s&vdi=%s&format=raw'
            % (session.handle, vdiuuid)]
     util.runlocal(cmd)


### PR DESCRIPTION
In case the VM and subsequently the config disk are on a different host, XAPI would return a 302 redirect.  We make sure here that the curl command issued would follow that redirect and bring back the raw data of the export_disk we seek.

This PR solves the second half of the problem described in #14 causing XenCenter to hang when looking at Properties of a VM hosted on a host other than the pool's master.

cc @robertbreker 
