### PR TITLE
CA-183332: Don't close stdin when listening for docker events

### DIFF
--- a/src/xscontainer/docker_monitor/__init__.py
+++ b/src/xscontainer/docker_monitor/__init__.py
@@ -128,7 +128,6 @@ class MonitoredVM(api_helper.VM):
                      % (cmd, vmuuid))
             stdin, stdout, _ = ssh_client.exec_command(cmd)
             stdin.write(docker.prepare_request_stdin('GET', '/events'))
-            stdin.channel.shutdown_write()
             self._ssh_client = ssh_client
             # Not that we are listening for events, get the latest state
             docker.update_docker_ps(self)


### PR DESCRIPTION
Calling stdin.channel.shutdown_write() worked fine in earlier environment
versions.
However, with the current versions shutdown_write triggers the event call to
return instantaneously (with rc=0), instead of waiting and listening as we'd
like it to. This is presumably down to a slightly different
(i.e. more complete) implementation of shutdown_write.

Signed-off-by: Robert Breker robert.breker@citrix.com
