### PR TITLE
Set cert file permissions correctly to allow running configure_tls.cm…

### DIFF
--- a/src/xscontainer/data/configure_tls.cmd
+++ b/src/xscontainer/data/configure_tls.cmd
@@ -20,13 +20,13 @@ echo Configuring the Docker daemon for TLS using %PROGRAMDATA%\Docker\certs.d
 if not exist %PROGRAMDATA%\docker\certs.d\ (
     mkdir %PROGRAMDATA%\docker\certs.d\ || goto :ERRORHANDLER
 )
-icacls.exe %PROGRAMDATA%\docker\certs.d\ /T /grant BUILTIN\Administrators:(OI)(CI)F /grant SYSTEM:(OI)(CI)F /inheritance:r || goto :ERRORHANDLER
+icacls.exe %PROGRAMDATA%\docker\certs.d\ /T /grant BUILTIN\Administrators:(OI)(CI)F /grant BUILTIN\Administrators:F /grant SYSTEM:(OI)(CI)F /grant SYSTEM:F /inheritance:r || goto :ERRORHANDLER
 xcopy /O %cdpath%server\* %PROGRAMDATA%\docker\certs.d\ || goto :ERRORHANDLER
 echo Configuring the Docker client in %USERPROFILE%\.docker\ to connect using TLS for the current user.
 if not exist %USERPROFILE%\.docker\ (
     mkdir %USERPROFILE%\.docker\ || goto :ERRORHANDLER
 )
-icacls.exe %USERPROFILE%\.docker\ /T /grant %USERDOMAIN%\%USERNAME%:(OI)(CI)F /inheritance:r || goto :ERRORHANDLER
+icacls.exe %USERPROFILE%\.docker\ /T /grant %USERDOMAIN%\%USERNAME%:(OI)(CI)F /grant %USERDOMAIN%\%USERNAME%:F /inheritance:r || goto :ERRORHANDLER
 xcopy /O %cdpath%client\* %USERPROFILE%\.docker\ || goto :ERRORHANDLER
 echo Restarting Docker.
 net stop Docker || goto :ERRORHANDLER


### PR DESCRIPTION
…d more than once

Problem:
We reset file permissions for the certificate files, which means that users
lose access access during the second installation.

Fix:
With this change, we'll configure sane permissions following the reset.

Signed-off-by: Robert Breker robert.breker@citrix.com
