### PR TITLE
Update python-crypto to 2.6.1-9

### DIFF
--- a/mk/Makefile
+++ b/mk/Makefile
@@ -62,8 +62,12 @@ DOM0_RPMS += /distros/CentOS/7.0.1406/EPEL-20140902/x86_64/p/python-ecdsa-0.11-3
 DOM0_SRPMS += /distros/CentOS/7.0.1406/EPEL-20140902/SRPMS/p/python-ecdsa-0.11-3.el7.src.rpm
 DOM0_RPMS += /distfiles/xscontainer/epel/2015-05-19/7/RPMS/x86_64/python-paramiko-1.15.1-1.el7.noarch.rpm
 DOM0_SRPMS += /distfiles/xscontainer/epel/2015-05-19/7/SRPMS/python-paramiko-1.15.1-1.el7.src.rpm
-DOM0_RPMS += /distros/CentOS/7.0.1406/EPEL-20140902/x86_64/p/python-crypto-2.6.1-1.el7.x86_64.rpm
-DOM0_SRPMS += /distros/CentOS/7.0.1406/EPEL-20140902/SRPMS/p/python-crypto-2.6.1-1.el7.src.rpm
+DOM0_RPMS += /distfiles/xscontainer/epel/2016-02-12/7/RPMS/python2-crypto-2.6.1-9.el7.x86_64.rpm
+DOM0_SRPMS += /distfiles/xscontainer/epel/2016-02-12/7/SRPMS/python-crypto-2.6.1-9.el7.src.rpm
+DOM0_RPMS += /distfiles/xscontainer/epel/2016-02-12/7/RPMS/libtomcrypt-1.17-23.el7.x86_64.rpm
+DOM0_SRPMS += /distfiles/xscontainer/epel/2016-02-12/7/SRPMS/libtomcrypt-1.17-23.el7.src.rpm
+DOM0_RPMS += /distfiles/xscontainer/epel/2016-02-12/7/RPMS/libtommath-0.42.0-4.el7.x86_64.rpm
+DOM0_SRPMS += /distfiles/xscontainer/epel/2016-02-12/7/SRPMS/libtommath-0.42.0-4.el7.src.rpm
 
 endif
 


### PR DESCRIPTION
Signed-off-by: Robert Breker robert.breker@citrix.com
