### PR TITLE
Fix SSH events broken in a12af19

### DIFF
--- a/src/xscontainer/remote_helper/ssh.py
+++ b/src/xscontainer/remote_helper/ssh.py
@@ -163,7 +163,7 @@ def execute_docker_data_listen(session, vmuuid, request,
             if not rlist:
                 continue
             try:
-                read_data = stdout.read(1024)
+                read_data = stdout.read(1)
                 if read_data == "":
                     break
                 yield read_data


### PR DESCRIPTION
The improvement doesn't appear to work for SSH as expected.
It will need some more work, that will be done separately.

Signed-off-by: Robert Breker robert.breker@citrix.com
