### PR TITLE
CA-265704: Replace etcd with etcd2 in cloud-config.template

### DIFF
--- a/src/xscontainer/data/cloud-config.template
+++ b/src/xscontainer/data/cloud-config.template
@@ -9,7 +9,7 @@ ssh_authorized_keys:
   - ssh-rsa %CONTAINERRSAPUB%
 coreos:
   units:
-    - name: etcd.service
+    - name: etcd2.service
       command: start
     - name: fleet.service
       command: start
@@ -37,10 +37,11 @@ coreos:
         [Service]
         ExecStartPre=/media/configdrive/agent/xe-linux-distribution /var/cache/xe-linux-distribution
         ExecStart=/media/configdrive/agent/xe-daemon
-  etcd:
+  etcd2:
     name: %VMNAMETOHOSTNAME%
-    # generate a new token for each unique cluster at https://discovery.etcd.io/new
-    # discovery: https://discovery.etcd.io/<token>
+    # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
+    # specify the initial cluster size using ?size=X
+    # discovery: "https://discovery.etcd.io/<token>"
 write_files:
   # Enable ARP notifications for smooth network recovery after migrations
   - path: /etc/sysctl.d/10-enable-arp-notify.conf


### PR DESCRIPTION
Referring to the non-existing etcd.service triggers a failure of the
service and prevents the guest agent from starting.

etcd2 was available since 681.0.0 (May 14, 2015), so
etcd was finally removed in 1409.2.0 (June 20, 2017).

Signed-off-by: Robert Breker <robert.breker@citrix.com>