### PR TITLE
CA-293156: Switch the TLS cipher suite to ECDHE-RSA-AES256-GCM-SHA384

### DIFF
--- a/src/xscontainer/remote_helper/tls.py
+++ b/src/xscontainer/remote_helper/tls.py
@@ -11,7 +11,7 @@ import socket
 import sys
 
 DOCKER_TLS_PORT = 2376
-TLS_CIPHER = "AES128-SHA"
+TLS_CIPHER = "ECDHE-RSA-AES256-GCM-SHA384"
 
 ERROR_CAUSE_NETWORK = (
     "Error: Cannot find a valid IP that allows TLS connections to Docker "


### PR DESCRIPTION
to fix the communication with Windows' Docker integration.

The latest version of Windows' Docker integration
has dropped support for AES128-SHA. Of the still supported
cipher suites, ECDHE-RSA-AES256-GCM-SHA384 appears
to be the safest choice.

Signed-off-by: Robert Breker <robert.breker@citrix.com>