### PR TITLE
CA-294519: xscontainer does not work with latest CoreOS as cloud-init…

### DIFF
--- a/src/xscontainer/data/cloud-config.template
+++ b/src/xscontainer/data/cloud-config.template
@@ -9,9 +9,7 @@ ssh_authorized_keys:
   - ssh-rsa %CONTAINERRSAPUB%
 coreos:
   units:
-    - name: etcd2.service
-      command: start
-    - name: fleet.service
+    - name: etcd-member.service
       command: start
 %HINEXISTS%
     # Avoid routing via host internal networks
@@ -37,7 +35,7 @@ coreos:
         [Service]
         ExecStartPre=/media/configdrive/agent/xe-linux-distribution /var/cache/xe-linux-distribution
         ExecStart=/media/configdrive/agent/xe-daemon
-  etcd2:
+  etcd:
     name: %VMNAMETOHOSTNAME%
     # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
     # specify the initial cluster size using ?size=X


### PR DESCRIPTION
CoreOS cloud-init, etcd and etcd2 depreciated

Fix this issue by upgrade the etcd configration in cloud-config template

Signed-off-by: Lin Liu <lin.liu@citrix.com>


test done:
dev manual test

XenServer version: 7.5
CoreOS version: 
- 1745.7
- 1800.2 
- 1800.6
- 1828.0
- 1828.3
- 1855.1
- 1871.0
