### PR TITLE
xscontainer: ignore SIG_PIPE

### DIFF
--- a/src/xscontainer-monitor
+++ b/src/xscontainer-monitor
@@ -1,9 +1,14 @@
 #!/usr/bin/env python
 
+from signal import signal, SIGPIPE
+
 import xscontainer.docker_monitor as docker_monitor
 
+def sig_handler(signo, frame):
+    raise IOError('Error: SIGPIPE received')
 
 def main():
+    signal(SIGPIPE, sig_handler)
     docker_monitor.monitor_host()
 
 

--- a/src/xscontainer/remote_helper/ssh.py
+++ b/src/xscontainer/remote_helper/ssh.py
@@ -85,7 +85,7 @@ def prepare_ssh_client(session, vmuuid):
     client.set_missing_host_key_policy(MyHostKeyPolicy(session, vmuuid))
     try:
         client.connect(host, port=SSH_PORT, username=username,
-                       pkey=pkey, look_for_keys=False)
+                       pkey=pkey, look_for_keys=False, banner_timeout=300)
     except SshException:
         # This exception is already improved - leave it as it is
         raise


### PR DESCRIPTION
During the dundeedockerlinux test, there are many SIG_PIPE throw out because pipe broken, which will cause xscontainer-monitor exit.
Ignore the single to avoid the failure.