### PR TITLE
Update util/__init__.py

### DIFF
--- a/src/xscontainer/util/__init__.py
+++ b/src/xscontainer/util/__init__.py
@@ -151,7 +151,7 @@ def convert_dict_to_ascii(item):
         for contained in item:
             result.append(convert_dict_to_ascii(contained))
     elif isinstance(item, unicode):
-        result = str(item)
+        result = item.encode('utf-8')
     else:
         result = item
     return result


### PR DESCRIPTION
Modified `convert_dict_to_ascii(item)` to convert to utf-8 instead. Some docker containers have values that are outside of the ascii range which causes xscontainer to crash with a `UnicodeEncodeError`. If ascii is absolutely necessary, line 154 could be changed to `item.encode('ascii', 'replace')` instead. I've tested the change to utf-8 on my system with no ill effects. 

If this is changed to utf-8, the function name and references should probably be updated to `convert_dict_to_utf8` as well. Didn't want to get ahead of myself in case this is a show stopper.